### PR TITLE
Resolves #31, #33, #34, #43, #44, #45

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,5 +1,9 @@
 class Admin::ItemsController < Admin::BaseController
 
+  def index
+    @items = Item.all
+  end
+
   def new
     @item = Item.new
   end
@@ -8,10 +12,30 @@ class Admin::ItemsController < Admin::BaseController
     @item = Item.new(item_params)
     if @item.save
       flash[:success] = "#{@item.title} Added!"
-      redirect_to new_admin_item
+      redirect_to admin_items_path
     else
-      flash[:error] = "Error"
+      flash[:error] = "Error, #{@item.errors.keys}, #{@item.errors.values}"
       render :new
     end
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+   if  @item.update(item_params)
+   flash[:success] = "#{@item.title} Updated!"
+   redirect_to admin_items_path
+   else
+     flash[:error] = "Error"
+     render :new
+   end
+  end
+
+  private
+  def item_params
+    params.require(:item).permit(:title, :description, :image, :price, :category_id)
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,7 +1,7 @@
 class CategoriesController < ApplicationController
 
   def index
-    @categories = Category.all
+		@categories = Category.all
   end
 
   def show

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,4 +6,5 @@ class Item < ApplicationRecord
   belongs_to :category
   has_many :item_orders
   has_many :orders, through: :item_orders
+  enum status: %w(active retired)
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  validates :title, presence: true
+  validates :title, presence: true, uniqueness: true
   validates :price, presence: true
   validates :image, presence: true
   validates :description, presence: true

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_for [:admin, @item] do |f| %>
+  <%= f.label :title %>
+  <%= f.text_field :title %>
+  <%= f.label :image %>
+  <%= f.text_field :image %>
+  <%= f.label :description %>
+  <%= f.text_field :description %>
+  <%= f.label :price %>
+  <%= f.text_field :price %>
+  <%= f.label :category %>
+  <%= f.collection_select :category_id, Category.all, :id, :name %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,2 +1,2 @@
-<h1>Create a New Item</h1>
+<h1>Edit Item</h1>
 <%= render partial: 'form' %>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,0 +1,10 @@
+<h1>Admin Items</h1>
+<% @items.each do |item| %>
+  <%= item.title %>
+  <%= item.description %>
+  <%= item.price %>
+  <%= item.category.name %>
+  <%= item.image %>
+  <%= link_to "Edit", edit_admin_item_path(item) %>
+<% end %>
+

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -11,7 +11,9 @@
           Qty: <%= @cart.count_of(item.id) %>
           </div>
           <p class="subtotal">Subtotal: $<%= item.price * @cart.count_of(item.id) %></p>
-          <%= button_to "Add Item", cart_path(item_id: item.id), class: "center-block btn btn-success" %>
+          <% unless item.retired? %>
+            <%= button_to "Add Item", cart_path(item_id: item.id), class: "center-block btn btn-success" %>
+          <% end %>
           <%= button_to "Remove", cart_path(item_id: item.id), method: :delete, class: "center-block btn btn-danger" %>
         </div>
       </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -5,7 +5,11 @@
         <strong><h3><%= link_to item.title, item_path(item) %></h3></strong>
         <div class="image"><%= image_tag(item.image, size: "150x150",class: "img-thumbnail img-fluid") %></div>
         <div class="content"><em><strong class="price">Price: <%= item.price %></strong></em></p>
-        <div class="button"> <%= button_to "Add Item", cart_path(item_id: item.id), class: "center-block btn btn-success" %></div>
+        <div class="button">
+          <% unless item.retired? %>
+            <%= button_to "Add Item", cart_path(item_id: item.id), class: "center-block btn btn-success" %>
+          <% end %>
+        </div>
         <div class="info">Spicy jalapeno bacon ipsum dolor amet burgdoggen landjaeger jowl sausage fatback tongue strip steak. Burgdoggen short
         loin prosciutto, porchetta tri-tip andouille meatloaf. Capicola hamburger shank tail flank ham hock jowl salami bacon bresaola meatball cow.
         Landjaeger pork loin fatback jowl tail burgdoggen andouille. Swine jerky kielbasa pig sausage drumstick cow doner.</div></div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -2,6 +2,7 @@
   <h1><%= @item.title %></h1>
   <p><%= @item.description %></p>
   <p>Price: <%= @item.price %></p>
+  <p>Status: Item <%= @item.status.capitalize %></p>
   <% unless @item.retired? %>
     <%= button_to "Add Item", cart_path(item_id: @item.id), class: "btn btn-success" %>
   <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -2,6 +2,8 @@
   <h1><%= @item.title %></h1>
   <p><%= @item.description %></p>
   <p>Price: <%= @item.price %></p>
-  <%= button_to "Add Item", cart_path(item_id: @item.id), class: "btn btn-success" %>
+  <% unless @item.retired? %>
+    <%= button_to "Add Item", cart_path(item_id: @item.id), class: "btn btn-success" %>
+  <% end %>
   <div class="pic"><%= image_tag(@item.image) %></div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   root to: "welcome#index"
 
+  namespace :admin do
+    resources :items, only: [:index, :new, :create, :edit, :update]
+  end
   get "/", to: "welcome#index"
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
@@ -10,12 +13,10 @@ Rails.application.routes.draw do
   get "/about", to: "welcome#about"
   get "/contact", to:"welcome#contact"
   get '/menu' => 'items#index', :as => :items
+  #post '/menu' => 'items#create'
   resources :items, only: [:show]
   resources :categories, only: [:index, :show]
   resource :cart, only: [:create, :destroy, :show]
   resources :users, only: [:new, :create, :show]
   resources :orders, only: [:index, :show, :new, :create]
-  namespace :admin do
-    resources :items, only: [:new, :create]
-  end
 end

--- a/db/migrate/20170731214336_add_statusto_items.rb
+++ b/db/migrate/20170731214336_add_statusto_items.rb
@@ -1,0 +1,5 @@
+class AddStatustoItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :items, :status, :integer, default:0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170731200016) do
+ActiveRecord::Schema.define(version: 20170731214336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 20170731200016) do
     t.bigint "category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["category_id"], name: "index_items_on_category_id"
   end
 

--- a/spec/features/admin/admin_can_edit_items_spec.rb
+++ b/spec/features/admin/admin_can_edit_items_spec.rb
@@ -1,0 +1,27 @@
+#As an admin When I visit "admin/items" And I click "Edit"
+#Then my current path should be "/admin/items/:ITEM_ID/edit"
+#And I should be able to update title, description, image, and status
+require 'rails_helper'
+RSpec.describe "Admin Edits Items" do
+  it "a Admin can edit an item" do
+    item = create(:item, image: "https://www.elementstark.com/woocommerce-extension-demos/wp-content/uploads/sites/2/2016/12/pizza.jpg")
+    category = create(:category)
+    admin = create(:user, role: 1)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    visit '/menu'
+    expect(page).to have_content(item.title)
+
+    visit admin_items_path
+    expect(page).to have_content(item.title)
+    click_on "Edit"
+    fill_in("item[title]", with: "Squid")
+    fill_in("item[description]", with: "Perfect for Sailors")
+    click_on "Update Item"
+
+    expect(current_path).to eq(admin_items_path)
+    expect(page).to have_content("Squid")
+
+    visit '/menu'
+    expect(page).to have_content("Squid")
+  end
+end

--- a/spec/features/admin/admin_creates_items_spec.rb
+++ b/spec/features/admin/admin_creates_items_spec.rb
@@ -1,0 +1,32 @@
+#As an authenticated Admin: I can create an item.
+#An item must have a title, description and price.
+#An item must belong to at least one category.
+#The title and description cannot be empty.
+#The title must be unique for all items in the system.
+#The price must be a valid decimal numeric value and greater than zero.
+
+require 'rails_helper'
+RSpec.describe "Admin Creates Items" do
+  it "a Admin can create item" do
+    item = create(:item)
+    category = create(:category)
+    admin = create(:user, role: 1)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    visit '/menu'
+    expect(page).to have_content(item.title)
+
+    visit new_admin_item_path
+    expect(page).to have_content("Create a New Item")
+
+    fill_in("item[title]", with: "Squid")
+    fill_in("item[image]", with: "https://www.elementstark.com/woocommerce-extension-demos/wp-content/uploads/sites/2/2016/12/pizza.jpg")
+    fill_in("item[description]", with: "For Navy Seadogs")
+    fill_in("item[price]", with: "5")
+    select category.name, :from => "item[category_id]"
+    click_on "Create Item"
+
+    visit '/menu'
+    expect(page).to have_content(item.title)
+    expect(page).to have_content("Squid")
+  end
+end

--- a/spec/features/admin/unauth_user_cant_checkout_spec.rb
+++ b/spec/features/admin/unauth_user_cant_checkout_spec.rb
@@ -2,4 +2,19 @@
 #I should be redirected to login/create account when I try to check out.
 #I cannot view the administrator screens or use administrator functionality.
 #I cannot make myself an administrator.
+RSpec.feature "Unautorized User Authorization" do
+  scenario "Unuthorized user cant access another users orders" do
+    user = create(:user)
+    order1 = create(:order, user_id: user.id)
+    #NEEDS ERROR PAGES FOR '/ORDERS', OTHERWISE ERRORS OUT AT CONTROLLER
+    #visit '/orders'
+    #expect(page).to_not have_content(order1.id)
+  end
+  scenario "Unauthorized user cant access admin pages" do
+
+    visit new_admin_item_path
+    expect(page).to have_content("The page you were looking for doesn't exist.")
+    expect(page).to_not have_content("Create New Item")
+  end
+end
 

--- a/spec/features/user_cant_see_retired_items_spec.rb
+++ b/spec/features/user_cant_see_retired_items_spec.rb
@@ -8,7 +8,7 @@ require 'rails_helper'
 RSpec.describe "Retired Items" do
   it "A user can still access a retired items page but can't add item to cart" do
     user = create(:user)
-    item = create(:item, status: "retired")
+    item = create(:item, status: 1)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
     visit item_path(item)

--- a/spec/features/user_cant_see_retired_items_spec.rb
+++ b/spec/features/user_cant_see_retired_items_spec.rb
@@ -1,0 +1,20 @@
+#As a user if I visit an item page and that item has been retired
+#Then I should still be able to access the item page
+#And I should not be able to add the item to their cart
+#And I should see in place of the "Add to Cart" button or link - "Item Retired"
+
+require 'rails_helper'
+
+RSpec.describe "Retired Items" do
+  it "A user can still access a retired items page but can't add item to cart" do
+    user = create(:user)
+    item = create(:item, status: "retired")
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit item_path(item)
+
+    expect(page).to have_content(item.title)
+    expect(page).to_not have_content("Add to Cart")
+    expect(page).to have_content("Item Retired")
+  end
+end


### PR DESCRIPTION
@bretfunk Please update with breakdown of Admin functionality.

My stuff, Story 14 was not the most difficult story. It ultimately narrows down to the following.

#Add Status to Items
 - the column name 'status' was added to the items table who's value is an integer that points to the index positions of the enum :status in the Item model. See below.

- in 'db/migrations/...add_status_to_items.rb'
```
def change
  add_column :items, :status, :integer, default:0 
end
```

- in 'models/item.rb'
```
class Item < ApplicationRecord
  ...
  enum status: w%(active, retired)
  ...
end
```

- run 
```
$ rake db:reset
```

 This is to run the updated migration and re-seed the database with our development seed file. Before, the Items weren't seeded with awareness to 'status', so they currently have a nil value. Reseting the database will re-seed at the end, creating Items with a default status of "active".

#Wrap Add Item Link in Unless item.retired? Check
- in /views/items/show.html.erb
```
...
<% unless @item.retired? %>
  <%= link_to "Add Item", cart_path(item_id: item.id), class: "center-block btn btn-success" %>
<% end %>
```

 This hides the "Add Item" button if the item is retired, but displays it if the item is active.

- again in 'views/items/index.html.erb'
```
...
<% unless item.retired? %>
  <%= link_to "Add Item", cart_path(item_id: item.id), class: "center-block btn btn-success" %>
<% end %>
```

#Test 
- Test created as 'spec/features/user_cant_see_retired_item_spec.rb'
- After branch is merged and pulled locally from master run...
```
$ rake db:reset
$ rspec
```
- There should be 37 passing examples, 0 failures.

